### PR TITLE
Separate IPMonad from LPMonad

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -9,7 +9,7 @@ import Math.Programming
 import Math.Programming.Glpk
 import Math.Programming.Glpk.Header
 
-simple :: (LPMonad m b) => m (b, b, b)
+simple :: (IPMonad m b) => m (b, b, b)
 simple = do
   z <- addVariable `named` "toDelete"
 
@@ -28,7 +28,7 @@ simple = do
 
   setObjective objective
   setSense Minimization
-  _ <- optimize
+  _ <- optimizeIP
 
   xVal <- evaluateVariable x
   yVal <- evaluate y

--- a/src/Math/Programming/Glpk.hs
+++ b/src/Math/Programming/Glpk.hs
@@ -58,14 +58,16 @@ instance LPMonad Glpk Double where
   setObjective = setObjective'
   setSense = setSense'
   optimizeLP = optimizeLP'
-  optimize = optimize'
   setVariableBounds = setVariableBounds'
-  setVariableDomain = setVariableDomain'
   evaluateVariable = evaluateVariable'
   evaluateExpression = evaluateExpression'
   setTimeout = setTimeout'
-  setRelativeMIPGap = setRelativeMIPGap'
   writeFormulation = writeFormulation'
+
+instance IPMonad Glpk Double where
+  optimizeIP = optimizeIP'
+  setVariableDomain = setVariableDomain'
+  setRelativeMIPGap = setRelativeMIPGap'
 
 runGlpk :: Glpk a -> IO (Either GlpkError a)
 runGlpk glpk = do
@@ -303,8 +305,8 @@ optimizeLP' =
         result <- glp_simplex problem controlPtr
         convertResult problem result
 
-optimize' :: Glpk SolutionStatus
-optimize' =
+optimizeIP' :: Glpk SolutionStatus
+optimizeIP' =
   let
     convertResult :: Ptr Problem -> GlpkMIPStatus -> IO SolutionStatus
     convertResult problem result

--- a/test/SimpleMIP.hs
+++ b/test/SimpleMIP.hs
@@ -14,7 +14,7 @@ test_simple = testGroup "Simple MIP problems"
   [ testCase "Simple MIP (GLPK)" simpleMIPGlpk
   ]
 
-simpleMIP :: (MonadIO m, LPMonad m Double) => m ()
+simpleMIP :: (MonadIO m, IPMonad m Double) => m ()
 simpleMIP = do
   x <- addVariable `asKind` Integer `within` Interval 0 5
   y <- addVariable `asKind` Continuous `within` Interval 0 5
@@ -23,7 +23,7 @@ simpleMIP = do
   setObjective (1 *: x .+. 1 *: y)
   setSense Minimization
   _ <- optimizeLP
-  status <- optimize
+  status <- optimizeIP
 
   -- Check that we reached optimality
   liftIO $ status @?= Optimal


### PR DESCRIPTION
There are LP solvers that cannot easily implement the integer programming components of the current monad; this PR introduces the `IPMonad` as a superclass of `LPMonad`.