### PR TITLE
Provide a default implementation for evaluateExpression

### DIFF
--- a/src/Math/Programming.hs
+++ b/src/Math/Programming.hs
@@ -74,6 +74,13 @@ class (Monad m, Num b) => LPMonad m b | m -> b where
 
   -- | Get the value of a linear expression in the current solution.
   evaluateExpression :: LinearExpr (Variable m) b -> m b
+  evaluateExpression (LinearExpr terms constant) =
+    let
+      variables = fmap fst terms
+      coefs = fmap snd terms
+    in do
+      values <- mapM evaluate variables
+      return $ constant + sum (zipWith (*) values coefs)
 
   -- | Write out the formulation.
   writeFormulation :: FilePath -> m ()

--- a/src/Math/Programming/Glpk.hs
+++ b/src/Math/Programming/Glpk.hs
@@ -60,7 +60,6 @@ instance LPMonad Glpk Double where
   optimizeLP = optimizeLP'
   setVariableBounds = setVariableBounds'
   evaluateVariable = evaluateVariable'
-  evaluateExpression = evaluateExpression'
   setTimeout = setTimeout'
   writeFormulation = writeFormulation'
 
@@ -366,17 +365,6 @@ evaluateVariable' variable = do
   problem <- askProblem
   column <- readColumn variable
   liftIO $ realToFrac <$> method problem column
-
-evaluateExpression'
-  :: LinearExpr (Variable Glpk) Double
-  -> Glpk Double
-evaluateExpression' (LinearExpr terms constant) =
-  let
-    variables = fmap fst terms
-    coefs = fmap snd terms
-  in do
-    values <- mapM evaluate variables
-    return $ constant + sum (zipWith (*) values coefs)
 
 setTimeout' :: Double -> Glpk ()
 setTimeout' seconds =


### PR DESCRIPTION
This could be provided as a convenience function outside the class,
but it is possible that some implementations could more efficiently
evaluate an entire expression.