### PR TITLE
LinearExpr tests

### DIFF
--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -1,0 +1,7 @@
+;;; Directory Local Variables
+;;; For more information see (info "(emacs) Directory Variables")
+
+((haskell-mode
+  (intero-targets "math-programming:lib" "math-programming:test:math-programming-test")
+  (eval intero-targets "math-programming:lib math-programming:tests")))
+

--- a/package.yaml
+++ b/package.yaml
@@ -43,3 +43,4 @@ tests:
       - tasty >= 1.1.0.2 && < 1.2
       - tasty-discover >= 4.2.0 && < 4.3
       - tasty-hunit >= 0.10.0.1 && < 0.11
+      - tasty-quickcheck >= 0.10 && < 0.11

--- a/src/Math/Programming.hs
+++ b/src/Math/Programming.hs
@@ -80,17 +80,11 @@ class (Monad m, Num b) => LPMonad m b | m -> b where
   setTimeout :: Double -> m ()
 
   -- | Get the value of a variable in the current solution.
-  eval :: Variable m -> m b
+  getValue :: Variable m -> m b
 
   -- | Get the value of a linear expression in the current solution.
-  evalExpr :: LinearExpr (Variable m) b -> m b
-  evalExpr (LinearExpr terms constant) =
-    let
-      variables = fmap fst terms
-      coefs = fmap snd terms
-    in do
-      values <- mapM eval variables
-      return $ constant + sum (zipWith (*) values coefs)
+  evalExpr :: LinearExpr b (Variable m) -> m b
+  evalExpr expr = traverse getValue expr >>= return . eval
 
   -- | Write out the formulation.
   writeFormulation :: FilePath -> m ()

--- a/src/Math/Programming.hs
+++ b/src/Math/Programming.hs
@@ -16,7 +16,6 @@ module Math.Programming
     -- ** Building constraints
   , module Math.Programming.Inequality
     -- ** Evaluating results
-  , Eval (..)
   , SolutionStatus (..)
     -- * Integer programs
   , IPMonad (..)
@@ -81,16 +80,16 @@ class (Monad m, Num b) => LPMonad m b | m -> b where
   setTimeout :: Double -> m ()
 
   -- | Get the value of a variable in the current solution.
-  evaluateVariable :: Variable m -> m b
+  eval :: Variable m -> m b
 
   -- | Get the value of a linear expression in the current solution.
-  evaluateExpression :: LinearExpr (Variable m) b -> m b
-  evaluateExpression (LinearExpr terms constant) =
+  evalExpr :: LinearExpr (Variable m) b -> m b
+  evalExpr (LinearExpr terms constant) =
     let
       variables = fmap fst terms
       coefs = fmap snd terms
     in do
-      values <- mapM evaluate variables
+      values <- mapM eval variables
       return $ constant + sum (zipWith (*) values coefs)
 
   -- | Write out the formulation.
@@ -183,22 +182,6 @@ asKind make domain = do
   variable <- make
   setVariableDomain variable domain
   return variable
-
--- | The class of objects that can contain numeric results from a math
--- program.
---
--- The 'evaluate' method can be used to query the value of either a
--- variable or a linear expression of variables from a math
--- program. It is important to note that the results of 'evaluate'
--- will only be meaningful after a call to an optimization routine.
-class (LPMonad m b) => Eval m a b where
-  evaluate :: a -> m b
-
-instance (LPMonad m b) => Eval m (Variable m) b where
-  evaluate = evaluateVariable
-
-instance (LPMonad m b) => Eval m (LinearExpr (Variable m) b) b where
-  evaluate = evaluateExpression
 
 -- | The class of objects that can be named by in a math program.
 --

--- a/src/Math/Programming.hs
+++ b/src/Math/Programming.hs
@@ -57,7 +57,7 @@ class (Monad m, Num b) => LPMonad m b | m -> b where
   setVariableBounds :: Variable m -> Bounds b -> m ()
 
   -- | Add a constraint to the model represented by an inequality.
-  addConstraint :: Inequality (Variable m) b -> m (Constraint m)
+  addConstraint :: Inequality b (Variable m) -> m (Constraint m)
 
   -- | Associate a name with a constraint.
   nameConstraint :: Constraint m -> String -> m ()
@@ -68,7 +68,7 @@ class (Monad m, Num b) => LPMonad m b | m -> b where
   deleteConstraint :: Constraint m -> m ()
 
   -- | Set the objective function of the model.
-  setObjective :: LinearExpr (Variable m) b -> m ()
+  setObjective :: LinearExpr b (Variable m) -> m ()
 
   -- | Set the optimization direction of the model.
   setSense :: Sense -> m ()

--- a/src/Math/Programming/Expr.hs
+++ b/src/Math/Programming/Expr.hs
@@ -39,6 +39,9 @@ instance (Num a) => Monoid (LinearExpr a b) where
 instance Functor (LinearExpr a) where
   fmap f (LinearExpr terms constant) = LinearExpr (fmap (fmap f) terms) constant
 
+instance Foldable (LinearExpr a) where
+  foldr f z (LinearExpr terms _) = foldr f z (fmap snd terms)
+
 sumExpr :: (Num a) => [LinearExpr a b] -> LinearExpr a b
 sumExpr = mconcat
 

--- a/src/Math/Programming/Expr.hs
+++ b/src/Math/Programming/Expr.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE InstanceSigs #-}
 {-| Symbolic linear expressions.
 
 This module defines operators to manipulate linear expressions. Note
@@ -11,87 +12,87 @@ module Math.Programming.Expr where
 
 import Data.List (sortOn)
 
--- | A linear expression containing variables of type @a@ and numeric
--- coefficients of type @b@.
+-- | A linear expression containing variables of type @b@ and numeric
+-- coefficients of type @a@.
 --
 -- Using strings to denote variables and 'Double's as our numeric
 -- type, we could express the term /3 x + 2 y + 1/ as
 --
 -- @
---   LinearExpr [("x", 3), ("y", 2")] 1
+--   LinearExpr [(3, "x"), (2, "y")] 1
 -- @
 data LinearExpr a b
   = LinearExpr
     { _terms :: [(a, b)]
-    , _constant :: b
+    , _constant :: a
     }
   deriving
     ( Read
     , Show
     )
 
-instance (Num b) => Semigroup (LinearExpr a b) where
+instance (Num a) => Semigroup (LinearExpr a b) where
   (<>) = (.+.)
 
-instance (Num b) => Monoid (LinearExpr a b) where
+instance (Num a) => Monoid (LinearExpr a b) where
   mempty = LinearExpr [] 0
 
-sumExpr :: (Num b) => [LinearExpr a b] -> LinearExpr a b
+sumExpr :: (Num a) => [LinearExpr a b] -> LinearExpr a b
 sumExpr = mconcat
 
-(*:) :: (Num b) => b -> a -> LinearExpr a b
-constant *: term = LinearExpr [(term, constant)] 0
+(*:) :: (Num a) => a -> b -> LinearExpr a b
+coef *: term = LinearExpr [(coef, term)] 0
 
-(.+.) :: (Num b) => LinearExpr a b -> LinearExpr a b -> LinearExpr a b
+(.+.) :: (Num a) => LinearExpr a b -> LinearExpr a b -> LinearExpr a b
 (LinearExpr terms constant) .+. (LinearExpr terms' constant')
   = LinearExpr (terms <> terms') (constant + constant')
 infixl 6 .+.
 
-(.+) :: (Num b) => LinearExpr a b -> b -> LinearExpr a b
+(.+) :: (Num a) => LinearExpr a b -> a -> LinearExpr a b
 ex .+ constant = ex .+. LinearExpr [] constant
 infixl 6 .+
 
-(+.) :: (Num b) => b -> LinearExpr a b -> LinearExpr a b
+(+.) :: (Num a) => a -> LinearExpr a b -> LinearExpr a b
 (+.) = flip (.+)
 infixl 6 +.
 
-(.-.) :: (Num b) => LinearExpr a b -> LinearExpr a b -> LinearExpr a b
+(.-.) :: (Num a) => LinearExpr a b -> LinearExpr a b -> LinearExpr a b
 ex .-. ex' = ex .+. (ex' .* (-1))
 infixl 6 .-.
 
-(.-) :: (Num b) => LinearExpr a b -> b -> LinearExpr a b
+(.-) :: (Num a) => LinearExpr a b -> a -> LinearExpr a b
 ex .- constant = ex .+ (negate constant)
 infixl 6 .-
 
-(-.) :: (Num b) => b -> LinearExpr a b -> LinearExpr a b
+(-.) :: (Num a) => a -> LinearExpr a b -> LinearExpr a b
 constant -. ex = constant +. ((-1) *. ex)
 infixl 6 -.
 
-(.*) :: (Num b) => LinearExpr a b -> b -> LinearExpr a b
+(.*) :: (Num a) => LinearExpr a b -> a -> LinearExpr a b
 LinearExpr terms constant .* coef
   = LinearExpr (fmap scale terms) (constant * coef)
   where
-    scale (x, y) = (x, y * coef)
+    scale (x, y) = (x * coef, y)
 infixl 7 .*
 
-(*.) :: (Num b) => b -> LinearExpr a b -> LinearExpr a b
+(*.) :: (Num a) => a -> LinearExpr a b -> LinearExpr a b
 (*.) = flip (.*)
 infixl 7 *.
 
-(./) :: (Num b, Fractional b) => LinearExpr a b -> b -> LinearExpr a b
+(./) :: (Num a, Fractional a) => LinearExpr a b -> a -> LinearExpr a b
 ex ./ coef = ex .* (1 / coef)
 infixl 7 ./
 
 -- | Combine equivalent terms by summing their coefficients
-simplify :: (Ord a, Num b) => LinearExpr a b -> LinearExpr a b
+simplify :: (Ord b, Num a) => LinearExpr a b -> LinearExpr a b
 simplify (LinearExpr terms constant)
-  = LinearExpr (reduce (sortOn fst terms)) constant
+  = LinearExpr (reduce (sortOn snd terms)) constant
   where
     reduce []           = []
-    reduce ((x, c): []) = [(x, c)]
-    reduce ((x, c): (x', c'): xs)
-      | x == x'   = (x, c + c') : reduce xs
-      | otherwise = (x, c) : reduce ((x', c'): xs)
+    reduce ((c, x): []) = [(c, x)]
+    reduce ((c, x): (c', x'): xs)
+      | x == x'   = (c + c', x) : reduce xs
+      | otherwise = (c, x) : reduce ((c', x'): xs)
 
 eval :: Num a => LinearExpr a a -> a
 eval (LinearExpr terms constant) = constant + sum (map (uncurry (*)) terms)

--- a/src/Math/Programming/Expr.hs
+++ b/src/Math/Programming/Expr.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE InstanceSigs #-}
 {-| Symbolic linear expressions.
 
 This module defines operators to manipulate linear expressions. Note
@@ -36,6 +35,9 @@ instance (Num a) => Semigroup (LinearExpr a b) where
 
 instance (Num a) => Monoid (LinearExpr a b) where
   mempty = LinearExpr [] 0
+
+instance Functor (LinearExpr a) where
+  fmap f (LinearExpr terms constant) = LinearExpr (fmap (fmap f) terms) constant
 
 sumExpr :: (Num a) => [LinearExpr a b] -> LinearExpr a b
 sumExpr = mconcat

--- a/src/Math/Programming/Expr.hs
+++ b/src/Math/Programming/Expr.hs
@@ -10,6 +10,7 @@ b'. For example, '.+.' adds two linear expressions together, while
 module Math.Programming.Expr where
 
 import Data.List (sortOn)
+import Data.Traversable (fmapDefault, foldMapDefault)
 
 -- | A linear expression containing variables of type @b@ and numeric
 -- coefficients of type @a@.
@@ -37,10 +38,10 @@ instance (Num a) => Monoid (LinearExpr a b) where
   mempty = LinearExpr [] 0
 
 instance Functor (LinearExpr a) where
-  fmap f (LinearExpr terms constant) = LinearExpr (fmap (fmap f) terms) constant
+  fmap = fmapDefault
 
 instance Foldable (LinearExpr a) where
-  foldr f z (LinearExpr terms _) = foldr f z (fmap snd terms)
+  foldMap = foldMapDefault
 
 instance Traversable (LinearExpr a) where
   traverse f (LinearExpr terms constant)

--- a/src/Math/Programming/Expr.hs
+++ b/src/Math/Programming/Expr.hs
@@ -42,6 +42,10 @@ instance Functor (LinearExpr a) where
 instance Foldable (LinearExpr a) where
   foldr f z (LinearExpr terms _) = foldr f z (fmap snd terms)
 
+instance Traversable (LinearExpr a) where
+  traverse f (LinearExpr terms constant)
+    = LinearExpr <$> traverse (traverse f) terms <*> pure constant
+
 sumExpr :: (Num a) => [LinearExpr a b] -> LinearExpr a b
 sumExpr = mconcat
 

--- a/src/Math/Programming/Expr.hs
+++ b/src/Math/Programming/Expr.hs
@@ -92,3 +92,6 @@ simplify (LinearExpr terms constant)
     reduce ((x, c): (x', c'): xs)
       | x == x'   = (x, c + c') : reduce xs
       | otherwise = (x, c) : reduce ((x', c'): xs)
+
+eval :: Num a => LinearExpr a a -> a
+eval (LinearExpr terms constant) = constant + sum (map (uncurry (*)) terms)

--- a/src/Math/Programming/Inequality.hs
+++ b/src/Math/Programming/Inequality.hs
@@ -10,38 +10,38 @@ data Inequality a b
     , Show
     )
 
-(.<=.) :: (Num b) => LinearExpr a b -> LinearExpr a b -> Inequality a b
+(.<=.) :: (Num a) => LinearExpr a b -> LinearExpr a b -> Inequality a b
 lhs .<=. rhs = Inequality (lhs .-. rhs) LT
 infix 4 .<=.
 
-(.<=) :: (Num b) => LinearExpr a b -> b -> Inequality a b
+(.<=) :: (Num a) => LinearExpr a b -> a -> Inequality a b
 lhs .<= rhs = lhs .<=. LinearExpr [] rhs
 infix 4 .<=
 
-(<=.) :: (Num b) => b -> LinearExpr a b -> Inequality a b
+(<=.) :: (Num a) => a -> LinearExpr a b -> Inequality a b
 lhs <=. rhs = LinearExpr [] lhs .<=. rhs
 infix 4 <=.
 
-(.>=.) :: (Num b) => LinearExpr a b -> LinearExpr a b -> Inequality a b
+(.>=.) :: (Num a) => LinearExpr a b -> LinearExpr a b -> Inequality a b
 lhs .>=. rhs = Inequality (lhs .-. rhs) GT
 infix 4 .>=.
 
-(.>=) :: (Num b) => LinearExpr a b -> b -> Inequality a b
+(.>=) :: (Num a) => LinearExpr a b -> a -> Inequality a b
 lhs .>= rhs = lhs .>=. LinearExpr [] rhs
 infix 4 .>=
 
-(>=.) :: (Num b) => b -> LinearExpr a b -> Inequality a b
+(>=.) :: (Num a) => a -> LinearExpr a b -> Inequality a b
 lhs >=. rhs = LinearExpr [] lhs .>=. rhs
 infix 4 >=.
 
-(.==.) :: (Num b) => LinearExpr a b -> LinearExpr a b -> Inequality a b
+(.==.) :: (Num a) => LinearExpr a b -> LinearExpr a b -> Inequality a b
 lhs .==. rhs = Inequality (lhs .-. rhs) EQ
 infix 4 .==.
 
-(.==) :: (Num b) => LinearExpr a b -> b -> Inequality a b
+(.==) :: (Num a) => LinearExpr a b -> a -> Inequality a b
 lhs .== rhs = lhs .==. LinearExpr [] rhs
 infix 4 .==
 
-(==.) :: (Num b) => b -> LinearExpr a b -> Inequality a b
+(==.) :: (Num a) => a -> LinearExpr a b -> Inequality a b
 lhs ==. rhs = LinearExpr [] lhs .==. rhs
 infix 4 ==.

--- a/test/TestLinearExpr.hs
+++ b/test/TestLinearExpr.hs
@@ -15,6 +15,7 @@ test_tree = testGroup "LinearExpression tests"
   [ testProperty "Additive commutativity" commutativityProp
   , testProperty "Additive distributivity" additiveDistributivityProp
   , testProperty "Coefficient commutativity" coefficientCommutativityProp
+  , testProperty "Scalar multiplicative distributivity" multiplicativeDistributivityProp
   ]
 
 type ExactExpr = LinearExpr (Ratio Integer) (Ratio Integer)
@@ -68,3 +69,7 @@ coefficientCommutativityProp (ShuffledCoefficients (shuffled, unshuffled))
 additiveDistributivityProp :: ExactExpr -> ExactExpr -> ExactExpr -> Bool
 additiveDistributivityProp x y z
   = eval ((x .+. y) .+. z) == eval (x .+. (y .+. z))
+
+multiplicativeDistributivityProp :: Ratio Integer -> ExactExpr -> Bool
+multiplicativeDistributivityProp a x
+  = eval (a *. x) == eval (x .* a)

--- a/test/TestLinearExpr.hs
+++ b/test/TestLinearExpr.hs
@@ -12,7 +12,8 @@ import Math.Programming.Expr
 
 test_tree :: TestTree
 test_tree = testGroup "LinearExpression tests"
-  [ testProperty "Commutativity" commutativityProp
+  [ testProperty "Additive commutativity" commutativityProp
+  , testProperty "Additive distributivity" additiveDistributivityProp
   , testProperty "Coefficient commutativity" coefficientCommutativityProp
   ]
 
@@ -63,3 +64,7 @@ instance Arbitrary ShuffledCoefficients where
 coefficientCommutativityProp :: ShuffledCoefficients -> Bool
 coefficientCommutativityProp (ShuffledCoefficients (shuffled, unshuffled))
   = eval shuffled == eval unshuffled
+
+additiveDistributivityProp :: ExactExpr -> ExactExpr -> ExactExpr -> Bool
+additiveDistributivityProp x y z
+  = eval ((x .+. y) .+. z) == eval (x .+. (y .+. z))

--- a/test/TestLinearExpr.hs
+++ b/test/TestLinearExpr.hs
@@ -37,7 +37,7 @@ instance LPMonad MockLP Double where
                          )
   data Constraint MockLP = Constraint
 
-  evaluateVariable = getVar
+  eval = getVar
 
   addVariable = error "MockLP addVariable"
   nameVariable = error "MockLP nameVariable"
@@ -65,11 +65,7 @@ example = M.fromList
   , (Variable "z", 3)
   ]
 
-ex :: MockLP Double
-ex = do
-  evaluate (((1.0 :: Double) *: Variable "x" .+. 2.0 *: Variable "y"))
-
 constantTest :: IO ()
 constantTest = runMockLP example $ do
-  value <- ex
+  value <- evalExpr $ 1.0 *: Variable "x" .+. 2.0 *: Variable "y"
   liftIO $ value @?= 5.0

--- a/test/TestLinearExpr.hs
+++ b/test/TestLinearExpr.hs
@@ -1,0 +1,75 @@
+{-# LANGUAGE DeriveFunctor #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE TypeFamilies #-}
+module TestLinearExpr where
+
+import Control.Monad.Reader
+import qualified Data.Map as M
+
+import Test.Tasty
+import Test.Tasty.HUnit
+
+import Math.Programming
+
+newtype MockLP a = MockLP { _runMockLP :: ReaderT (M.Map (Variable MockLP) Double) IO a }
+  deriving
+    ( Functor
+    , Applicative
+    , Monad
+    , MonadIO
+    , MonadReader (M.Map (Variable MockLP) Double)
+    )
+
+getVar :: Variable MockLP -> MockLP Double
+getVar var = asks (M.findWithDefault (read "NaN") var)
+
+runMockLP :: M.Map (Variable MockLP) Double -> MockLP a -> IO a
+runMockLP vars actions = runReaderT (_runMockLP actions) vars
+
+instance LPMonad MockLP Double where
+  data Variable MockLP = Variable { fromVariable :: String }
+                       deriving
+                         ( Eq
+                         , Ord
+                         , Show
+                         )
+  data Constraint MockLP = Constraint
+
+  evaluateVariable = getVar
+
+  addVariable = error "MockLP addVariable"
+  nameVariable = error "MockLP nameVariable"
+  deleteVariable = error "MockLP deleteVariable"
+  addConstraint = error "MockLP addConstraint"
+  nameConstraint = error "MockLP nameConstraint"
+  deleteConstraint = error "MockLP deleteConstraint"
+  setObjective = error "MockLP setObjective"
+  setSense = error "MockLP setSense"
+  optimizeLP = error "MockLP optimizeLP"
+  setVariableBounds = error "MockLP setVariableBounds"
+  setTimeout = error "MockLP setTimeout"
+  writeFormulation = error "MockLP writeFormulation"
+
+test_simple_expressions :: TestTree
+test_simple_expressions = testGroup "Simple expressions"
+  [ testCase "Constants" constantTest
+  ]
+
+example :: M.Map (Variable MockLP) Double
+example = M.fromList
+  [ (Variable "w", 0)
+  , (Variable "x", 1)
+  , (Variable "y", 2)
+  , (Variable "z", 3)
+  ]
+
+ex :: MockLP Double
+ex = do
+  evaluate (((1.0 :: Double) *: Variable "x" .+. 2.0 *: Variable "y"))
+
+constantTest :: IO ()
+constantTest = runMockLP example $ do
+  value <- ex
+  liftIO $ value @?= 5.0

--- a/test/TestLinearExpr.hs
+++ b/test/TestLinearExpr.hs
@@ -13,7 +13,7 @@ import Math.Programming.Expr
 test_tree :: TestTree
 test_tree = testGroup "LinearExpression tests"
   [ testProperty "Additive commutativity" commutativityProp
-  , testProperty "Additive distributivity" additiveDistributivityProp
+  , testProperty "Additive associativity" additiveAssociativityProp
   , testProperty "Coefficient commutativity" coefficientCommutativityProp
   , testProperty "Scalar multiplicative distributivity" multiplicativeDistributivityProp
   ]
@@ -66,8 +66,8 @@ coefficientCommutativityProp :: ShuffledCoefficients -> Bool
 coefficientCommutativityProp (ShuffledCoefficients (shuffled, unshuffled))
   = eval shuffled == eval unshuffled
 
-additiveDistributivityProp :: ExactExpr -> ExactExpr -> ExactExpr -> Bool
-additiveDistributivityProp x y z
+additiveAssociativityProp :: ExactExpr -> ExactExpr -> ExactExpr -> Bool
+additiveAssociativityProp x y z
   = eval ((x .+. y) .+. z) == eval (x .+. (y .+. z))
 
 multiplicativeDistributivityProp :: Ratio Integer -> ExactExpr -> Bool


### PR DESCRIPTION
Add tests to ensure that linear expressions satisfy:

1. Additive commutativity
1. Additive associativity
1. Multiplicative associativity
1. Scalar multiplicative distributivity

This PR also makes `LinearExpr a` into `Functor`, `Foldable`, and `Traversable`. This greatly simplifies the interface for substituting values.