### PR TITLE
Simplify call sites

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,3 +1,21 @@
 # Changelog for math-programming
 
-## Unreleased changes
+## [0.4.0] -- 5 July 2020
+### Added
+
+- The `RealFrac` constraint on `LPMonad` numeric types.
+
+  This simplifies the constraints necessary in application code.
+
+### Removed
+
+- The `writeFormulation` class method.
+
+  This was impossible to implement correctly without requiring
+  `LPMonad` to implement `MonadIO`, which should not be required in
+  general.
+
+
+## [0.3.0] -- 18 June 2020
+
+Initial release.

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name:                math-programming
-version:             0.3.0
+version:             0.4.0
 github:              "prsteele/math-programming"
 license:             BSD3
 author:              "Patrick Steele"

--- a/src/Math/Programming/Types.hs
+++ b/src/Math/Programming/Types.hs
@@ -108,9 +108,6 @@ class (Monad m, Show (Numeric m), RealFrac (Numeric m)) => LPMonad m where
   -- | Optimize the continuous relaxation of the model.
   optimizeLP :: m SolutionStatus
 
-  -- | Write out the formulation.
-  writeFormulation :: FilePath -> m ()
-
 -- | A (mixed) integer program.
 --
 -- In addition to the methods of the 'LPMonad' class, this monad

--- a/src/Math/Programming/Types.hs
+++ b/src/Math/Programming/Types.hs
@@ -16,7 +16,7 @@ type Expr m = LinearExpression (Numeric m) (Variable m)
 --
 -- We manipulate linear programs and their settings using the
 -- 'Mutable' typeclass.
-class (Monad m, Num (Numeric m)) => LPMonad m where
+class (Monad m, Show (Numeric m), RealFrac (Numeric m)) => LPMonad m where
   -- | The numeric type used in the model.
   type Numeric m :: *
 


### PR DESCRIPTION
This PR is intended to simplify the constraints needed at call sites. In particular, it makes stronger assumptions about the numeric types in the `LPMonad`, and removes the (implicit) requirement that `LPMonad` implement `MonadIO`.